### PR TITLE
[FEAT] 네이버 로그인 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,16 +30,12 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
-    viewBinding {
-        enabled = true
-    }
     dataBinding {
         enabled = true
     }
 }
 
 dependencies {
-
     implementation 'androidx.core:core-ktx:1.8.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.5.0'
@@ -47,4 +43,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    implementation 'com.navercorp.nid:oauth:5.1.1'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -13,13 +13,16 @@
         android:theme="@style/Theme.HDmedi"
         tools:targetApi="31">
         <activity
-            android:name=".activity.MainActivity"
+            android:name=".activity.LoginActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".activity.MainActivity"
+            android:exported="true">
         </activity>
     </application>
 

--- a/app/src/main/java/com/example/hdmedi/activity/LoginActivity.kt
+++ b/app/src/main/java/com/example/hdmedi/activity/LoginActivity.kt
@@ -1,0 +1,55 @@
+package com.example.hdmedi.activity
+
+import android.content.Intent
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.util.Log
+import android.widget.Button
+import com.example.hdmedi.R
+import com.navercorp.nid.NaverIdLoginSDK
+import com.navercorp.nid.oauth.NidOAuthLogin
+import com.navercorp.nid.oauth.OAuthLoginCallback
+import com.navercorp.nid.profile.NidProfileCallback
+import com.navercorp.nid.profile.data.NidProfileResponse
+
+class LoginActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_login)
+
+        val button = findViewById<Button>(R.id.naverLoginButton)
+        button.setOnClickListener {
+            NaverIdLoginSDK.initialize(this@LoginActivity, getString(R.string.naver_client_id), getString(R.string.naver_client_secret), "앱 이름")
+            NaverIdLoginSDK.authenticate(this@LoginActivity, oAuthLoginCallback)
+        }
+    }
+
+    private val oAuthLoginCallback = object : OAuthLoginCallback {
+        override fun onSuccess() {
+            NidOAuthLogin().callProfileApi(object : NidProfileCallback<NidProfileResponse> {
+                override fun onSuccess(result: NidProfileResponse) {
+                    val naverAccessToken = NaverIdLoginSDK.getAccessToken()
+                    Log.e("login", "naverAccessToken : $naverAccessToken")
+
+                    Intent(this@LoginActivity, MainActivity::class.java).apply {
+                        startActivity(this)
+                    }
+                }
+
+                override fun onError(errorCode: Int, message: String) {
+                    Log.e("login", message)
+                }
+
+                override fun onFailure(httpStatus: Int, message: String) {
+                    Log.e("login", message)
+                }
+            })
+        }
+
+        override fun onError(errorCode: Int, message: String) {}
+
+        override fun onFailure(httpStatus: Int, message: String) {}
+    }
+
+
+}

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".activity.LoginActivity">
+
+    <Button
+        android:id="@+id/naverLoginButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="login"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">HDmedi</string>
+    <string name="naver_client_id">ugO442Swhk_dkXbq4HVV</string>
+    <string name="naver_client_secret">9OGzIhrOjQ</string>
 </resources>


### PR DESCRIPTION
## Summary
- 네이버 로그인 구현

## Description
- 로그인 액티비티 파일을 생성하였습니다.
- 앱 실행시 로그인 액티비티가 가장 먼저 실행되도록 `AndroidManifest.xml` 파일에서 intent-filter를 수정하였고 `LoginAcitvity`의 `exported`를 `true`로 설정하였습니다.
- `AndroidManifest.xml` 파일에서 인터넷 권한을 추가하였습니다.
- (DataBinding이 이미 선언되있기 때문에) 앱수준 `build.gradle`에서 ViewBinding을 제거해주었습니다.
- 네이버 로그인 구현을 위해 앱수준 `build.gradle`에서 코루틴, 네이버 oauth 의존성을 추가해주었습니다.
- `string.xml`에서 네이버 로그인 api 사용에 필요한 client id, serect key를 추가하였습니다.
- 네이버 소셜 로그인 기능을 구현하였습니다.