### PR TITLE
Feat. 스플래쉬 화면 배경 색상, 로고 이미지 설정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,19 +19,20 @@
             android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-
+        </activity>
+        <activity
+            android:name=".activity.OnBoardingActivity"
+            android:exported="true">
         </activity>
         <activity
             android:name=".activity.LoginActivity"
             android:exported="true">
-
         </activity>
         <activity
             android:name=".activity.MainActivity"
-            android:exported="true"></activity>
+            android:exported="true">
+        </activity>
     </application>
-
 </manifest>

--- a/app/src/main/java/com/example/hdmedi/activity/SplashActivity.kt
+++ b/app/src/main/java/com/example/hdmedi/activity/SplashActivity.kt
@@ -7,17 +7,14 @@ import android.os.Handler
 import com.example.hdmedi.R
 
 class SplashActivity : AppCompatActivity() {
-
     private val splash_delay : Long = 2000
-
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_splash)
 
-
         Handler().postDelayed({
-            val intent = Intent(this@SplashActivity, LoginActivity::class.java)
+            val intent = Intent(this@SplashActivity, OnBoardingActivity::class.java)
             startActivity(intent)
             finish()
         }, splash_delay)

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -4,13 +4,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".activity.SplashActivity">
-
+    tools:context=".activity.SplashActivity"
+    android:background="#23E191">
     <ImageView
-        android:id="@+id/splash_image"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:src="@drawable/ic_launcher_background"/>
-
-
+        android:layout_width="220dp"
+        android:layout_height="70dp"
+        android:background="@drawable/logo"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
-  스플래쉬 화면 배경 색상, 로고 이미지 설정

## Description
- screenshot
   <img src="https://github.com/KusitmsHDmedi/HDmedi_Android/assets/63611804/812a2a6c-fd92-499e-8fa5-966be89d6ea3" width="30%" height="30%"/>

- 스플래쉬 화면이 끝나면 온보딩 화면으로 넘어가도록 수정
