### PR TITLE
[Fix] 아이 코드 입력 UI의 다음 버튼 텍스트의 폰트, 색상, 크기 수정

### DIFF
--- a/app/src/main/java/com/example/hdmedi/activity/TeacherSettingActivity.kt
+++ b/app/src/main/java/com/example/hdmedi/activity/TeacherSettingActivity.kt
@@ -31,7 +31,7 @@ class TeacherSettingActivity : BaseActivity<ActivityTeacherSettingBinding>(R.lay
             }else{
                 view.isSelected = b
                 binding.nextButton.isActivated = false
-                binding.nextButton.setTextColor(Color.BLACK)
+                binding.nextButton.setTextColor(getColor(R.color.gray700))
             }
         }
     }

--- a/app/src/main/res/layout/activity_teacher_setting.xml
+++ b/app/src/main/res/layout/activity_teacher_setting.xml
@@ -51,6 +51,9 @@
             app:layout_constraintBottom_toBottomOf="parent"
             android:layout_marginBottom="28dp"
             android:text="다음"
+            android:fontFamily="@font/pretendard_semibold"
+            android:textSize="16sp"
+            android:textColor="@color/gray700"
             android:background="@drawable/button_selector"/>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,4 +4,5 @@
     <color name="white">#FFFFFFFF</color>
     <color name="main_color">#2BAE76</color>
     <color name="gray">#8E95A3</color>
+    <color name="gray700">#595F72</color>
 </resources>


### PR DESCRIPTION
## Summary
- 다음 버튼 텍스트의 폰트, 색상, 크기 수정

## Description
- 폰트 : `pretendard_semibold` 적용
- 색상 : 버튼 비활성화시 black -> `#595F72` 로 수정
- 텍스트 사이즈 : 16sp 적용